### PR TITLE
#10 - Generate menu shows Parcelable for Interfaces and Enums

### DIFF
--- a/src/pl/charmas/parcelablegenerator/ParcelableAction.java
+++ b/src/pl/charmas/parcelablegenerator/ParcelableAction.java
@@ -56,17 +56,20 @@ public class ParcelableAction extends AnAction {
     @Override
     public void update(AnActionEvent e) {
         PsiClass psiClass = getPsiClassFromContext(e);
-        e.getPresentation().setEnabled(psiClass != null);
+        e.getPresentation().setEnabled(psiClass != null && !psiClass.isEnum() && !psiClass.isInterface());
     }
 
     private PsiClass getPsiClassFromContext(AnActionEvent e) {
         PsiFile psiFile = e.getData(LangDataKeys.PSI_FILE);
         Editor editor = e.getData(PlatformDataKeys.EDITOR);
+
         if (psiFile == null || editor == null) {
             return null;
         }
+
         int offset = editor.getCaretModel().getOffset();
         PsiElement element = psiFile.findElementAt(offset);
+        
         return PsiTreeUtil.getParentOfType(element, PsiClass.class);
     }
 }


### PR DESCRIPTION
Removes Parcelable from Generate menu when type is enum or interface
