### PR TITLE
Make CREATOR final to prevent it obfuscation

### DIFF
--- a/src/pl/charmas/parcelablegenerator/CodeGenerator.java
+++ b/src/pl/charmas/parcelablegenerator/CodeGenerator.java
@@ -50,7 +50,7 @@ public class CodeGenerator {
     }
 
     private String generateStaticCreator(PsiClass psiClass) {
-        StringBuilder sb = new StringBuilder("public static android.os.Parcelable.Creator<");
+        StringBuilder sb = new StringBuilder("public static final android.os.Parcelable.Creator<");
 
         String className = psiClass.getName();
 


### PR DESCRIPTION
Default proguard config don't obfuscate only public static **final** CREATOR fields. See file 
%ANDROID_HOME%/tools/proguard/proguard-android.txt:

```
-keep class * implements android.os.Parcelable {
  public static final android.os.Parcelable$Creator *;
}
```
