### PR TITLE
Add support for Short reference data type

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Just press **ALT + Insert** (or your equivalent keybinding for code generation) 
  * Types implementing Serializable
  * List of `Parcelable` objects
  * Enumerations
- * Primitive types: `long`, `int`, `float`, `double`, `boolean`, `byte`, `String`
- * Primitive type wrappers (written with `Parcel.writeValue(Object)`): `Integer`, `Long`, `Float`, `Double`, `Boolean`, `Byte`
+ * Primitive types: `long`, `short`, `int`, `float`, `double`, `boolean`, `byte`, `String`
+ * Primitive type wrappers (written with `Parcel.writeValue(Object)`): `Short`, `Integer`, `Long`, `Float`, `Double`, `Boolean`, `Byte`
  * Primitive type arrays: `boolean[]`, `byte[]`, `char[]`, `double[]`, `float[]`, `int[]`, `long[]`
  * List type of any object (**Warning: validation is not performed**)
 

--- a/src/pl/charmas/parcelablegenerator/typeserializers/PrimitiveTypeSerializerFactory.java
+++ b/src/pl/charmas/parcelablegenerator/typeserializers/PrimitiveTypeSerializerFactory.java
@@ -20,6 +20,7 @@ import pl.charmas.parcelablegenerator.typeserializers.serializers.BooleanPrimiti
 import pl.charmas.parcelablegenerator.typeserializers.serializers.CharPrimitiveSerializer;
 import pl.charmas.parcelablegenerator.typeserializers.serializers.NullablePrimitivesSerializer;
 import pl.charmas.parcelablegenerator.typeserializers.serializers.PrimitiveTypeSerializer;
+import pl.charmas.parcelablegenerator.typeserializers.serializers.ShortPrimitiveSerializer;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -37,6 +38,7 @@ public class PrimitiveTypeSerializerFactory implements TypeSerializerFactory {
         writeMethodsForTypes.put("byte", new PrimitiveTypeSerializer("Byte"));
         writeMethodsForTypes.put("double", new PrimitiveTypeSerializer("Double"));
         writeMethodsForTypes.put("float", new PrimitiveTypeSerializer("Float"));
+        writeMethodsForTypes.put("short", new ShortPrimitiveSerializer());
         writeMethodsForTypes.put("int", new PrimitiveTypeSerializer("Int"));
         writeMethodsForTypes.put("long", new PrimitiveTypeSerializer("Long"));
         writeMethodsForTypes.put("java.lang.String", new PrimitiveTypeSerializer("String"));
@@ -48,6 +50,7 @@ public class PrimitiveTypeSerializerFactory implements TypeSerializerFactory {
         writeMethodsForTypes.put("java.lang.Byte", new NullablePrimitivesSerializer("java.lang.Byte"));
         writeMethodsForTypes.put("java.lang.Double", new NullablePrimitivesSerializer("java.lang.Double"));
         writeMethodsForTypes.put("java.lang.Float", new NullablePrimitivesSerializer("java.lang.Float"));
+        writeMethodsForTypes.put("java.lang.Short", new NullablePrimitivesSerializer("java.lang.Short"));
         writeMethodsForTypes.put("java.lang.Integer", new NullablePrimitivesSerializer("java.lang.Integer"));
         writeMethodsForTypes.put("java.lang.Long", new NullablePrimitivesSerializer("java.lang.Long"));
         writeMethodsForTypes.put("java.lang.Boolean", new NullablePrimitivesSerializer("java.lang.Boolean"));

--- a/src/pl/charmas/parcelablegenerator/typeserializers/serializers/ShortPrimitiveSerializer.java
+++ b/src/pl/charmas/parcelablegenerator/typeserializers/serializers/ShortPrimitiveSerializer.java
@@ -1,0 +1,18 @@
+package pl.charmas.parcelablegenerator.typeserializers.serializers;
+
+import com.intellij.psi.PsiField;
+
+import pl.charmas.parcelablegenerator.typeserializers.TypeSerializer;
+
+public class ShortPrimitiveSerializer implements TypeSerializer {
+
+    @Override
+    public String writeValue(PsiField field, String parcel, String flags) {
+        return parcel + ".writeInt(" + field.getName() + ");";
+    }
+
+    @Override
+    public String readValue(PsiField field, String parcel) {
+        return "this." + field.getName() + " = (short) " + parcel + ".readInt();";
+    }
+}


### PR DESCRIPTION
Just discovered that `Short` as a reference data type is not supported in this plugin.

I don't know what to do with primitive `short`. `Parcel` doesn't have a method for primitive `short`. There are three ways I can think of right now.
* Do a widening conversion to `int`? Kind of wasteful and there might not be compiler errors if data type gets changed.
* Autobox to `Short`?
* Just treat it as a `Serializable`?

I don't know. But this PR should be good for `Short`.