### PR TITLE
Write booleans as ints to parcel

### DIFF
--- a/src/pl/charmas/parcelablegenerator/typeserializers/serializers/BooleanPrimitiveSerializer.java
+++ b/src/pl/charmas/parcelablegenerator/typeserializers/serializers/BooleanPrimitiveSerializer.java
@@ -22,11 +22,11 @@ public class BooleanPrimitiveSerializer implements TypeSerializer {
 
     @Override
     public String writeValue(PsiField field, String parcel, String flags) {
-        return parcel + ".writeByte(" + field.getName() + " ? (byte) 1 : (byte) 0);";
+        return parcel + ".writeInt(" + field.getName() + " ? 1 : 0);";
     }
 
     @Override
     public String readValue(PsiField field, String parcel) {
-        return "this." + field.getName() + " = " + parcel + ".readByte() != 0;";
+        return "this." + field.getName() + " = " + parcel + ".readInt() != 0;";
     }
 }


### PR DESCRIPTION
[When calling `Parcel.writeByte()`, it just calls `Parcel.writeInt()` anyway.](https://github.com/android/platform_frameworks_base/blob/master/core/java/android/os/Parcel.java#L609)